### PR TITLE
Feat: Dockerize web

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Node assets
+node_modules
+npm-debug.log
+
+
+# Git config
+.git/
+.gitignore
+.github/
+
+# Docker
+.dockerignore
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM --platform=linux/amd64 node:lts-alpine as builder
+
+# Create app directory
+WORKDIR /app
+
+# Install app dependencies
+COPY package*.json ./
+
+RUN npm install
+
+# Copy app source code
+COPY . .
+
+# Build static assets
+RUN npm run export
+
+FROM --platform=linux/amd64 nginx:alpine
+
+# Copy static assets from builder stage
+COPY --from=builder /app/out /usr/share/nginx/html
+
+EXPOSE 80
+
+


### PR DESCRIPTION
Primera versión dockerizada. Se puede ejecutar nateando cualquier puerto al 80 del contenedor. A posteriori se le puede añadir certificados o cualquier configuración, pero como primera versión, a ver que os parece. 

Comandos de prueba:
`docker build . -t cloudrioja`
`docker run -p 8080:80 cloudrioja`

No soy muy diestro en node/nextjs seguramente se pueda optimizar más el proceso.

Un saludo!